### PR TITLE
Use alpine 3.19 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/connecteurs/alpine
+FROM ghcr.io/connecteurs/alpine:v3.19.1
 
 RUN apk add --no-cache \
   alpine-conf \
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
   aports-build \
   sudo
 
-COPY --from=ghcr.io/connecteurs/directory-index \
+COPY --from=ghcr.io/connecteurs/directory-index:v0.2.0 \
   /bin/directory_index \
   /bin/directory_index
 


### PR DESCRIPTION
This uses Alpine 3.19 as base image.
It also specifies a precise version for the `directory_index` tool that we want to ship.